### PR TITLE
Robust computation of the probability weights

### DIFF
--- a/error_parity/classifiers.py
+++ b/error_parity/classifiers.py
@@ -279,11 +279,17 @@ class RandomizedClassifier(Classifier):
                 f"should be 1!"
             )
 
-        if not all(np.isclose(target_point, all_weights @ all_points)):
+        if not all(np.isclose(target_point, all_weights @ all_points, atol=1e-5)):
             raise RuntimeError(
                 f"Triangulation of target point failed. "
                 f"Target was {target_point}; got {all_weights @ all_points}."
             )
+        
+        if (all_weights < 0).any():
+            all_weights = np.asarray(all_weights)
+            x_max = np.amax(all_weights, axis=0, keepdims=True)
+            exp_x_shifted = np.exp(all_weights - x_max)
+            all_weights = exp_x_shifted / np.sum(exp_x_shifted, axis=0, keepdims=True)
 
         return all_weights, all_points
 


### PR DESCRIPTION
Robust probability computation of weights

```
Traceback (most recent call last):
  File "postprocessing.py", line 240, in <module>
    pipeline(load_fn=dataset_name_to_load_fn[dataset_name],
  File "postprocessing.py", line 208, in pipeline
    unprocessed_clf.fit(X=data_splits['X_' + fit_data], y=data_splits['y_' + fit_data], group=data_splits['s_' + fit_data])
  File "error_parity/threshold_optimizer.py", line 485, in fit
    g: RandomizedClassifier.construct_at_target_ROC(
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "error_parity/classifiers.py", line 372, in construct_at_target_ROC
    weights, points = RandomizedClassifier.find_weights_given_two_points(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "error_parity/classifiers.py", line 283, in find_weights_given_two_points
    raise RuntimeError(
RuntimeError: Triangulation of target point failed. Target was [5.65363161e-07 5.42325664e-07]; got [5.42325665e-07 5.42325665e-07].
```

The issue has been found using "ACSDataSource(survey_year='2018', horizon='1-Year', survey='person')" as dataset, with the basic problem "ACSEmployment". The split is 70-10-20 using the function train_test_split of sklearn with shuffle=True, stratify on sensitive attribute (RAC1P) and seed 42. Moreover, the RelaxedThreshold had equalized odds as constraint and threshold 1.0 (The experiment involves FairGBM as model).   