### PR TITLE
Migrating to CLARABEL solver as cvxpy is deprecating ECOS

### DIFF
--- a/error_parity/_version.py
+++ b/error_parity/_version.py
@@ -1,3 +1,3 @@
 """File to keep the package version in one place."""
-__version__ = "0.3.12"
+__version__ = "0.3.13"
 __version_info__ = tuple(__version__.split("."))

--- a/error_parity/cvxpy_utils.py
+++ b/error_parity/cvxpy_utils.py
@@ -415,15 +415,15 @@ def compute_fair_optimum(   # noqa: C901
     prob = cp.Problem(obj, constraints)
 
     # Run solver
-    prob.solve(solver=cp.ECOS, abstol=SOLUTION_TOLERANCE, feastol=SOLUTION_TOLERANCE)
+    # prob.solve(solver=cp.ECOS, abstol=SOLUTION_TOLERANCE, feastol=SOLUTION_TOLERANCE)
 
     # NOTE: ECOS solver has been deprecated in favor of CLARABEL in cvxpy 1.3.2+
     # https://www.cvxpy.org/updates/index.html?h=ecos#ecos-deprecation
-    # prob.solve(
-    #     solver=cp.CLARABEL,
-    #     tol_gap_abs=SOLUTION_TOLERANCE,
-    #     tol_feas=SOLUTION_TOLERANCE,
-    # )
+    prob.solve(
+        solver=cp.CLARABEL,
+        tol_gap_abs=SOLUTION_TOLERANCE,
+        tol_feas=SOLUTION_TOLERANCE,
+    )
     # NOTE: these tolerances are supposed to be smaller than the default np.isclose tolerances
     # (useful when comparing if two points are the same, within the cvxpy accuracy tolerance)
 

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,8 +1,8 @@
 pandas
-numpy<2.0.0
+numpy
 scipy
 tqdm
 scikit-learn>=1.2
-cvxpy[ecos,clarabel]~=1.3.2
+cvxpy[clarabel]>=1.3.2
 matplotlib
 seaborn


### PR DESCRIPTION
Migrating to the CLARABEL solver should make this `error-parity` version compatible with newer versions of `numpy` and `cvxpy>=1.3.2`.